### PR TITLE
suggestion: using pecentage from edge to trigger page turn

### DIFF
--- a/library/res/values/dimens.xml
+++ b/library/res/values/dimens.xml
@@ -4,6 +4,6 @@
     <dimen name="padding_medium">8dp</dimen>
     <dimen name="padding_large">16dp</dimen>
     
-    <dimen name="touch_start_padding">32dp</dimen>
-
+	<dimen name="touch_from_edge_percentage">10dp</dimen>
+	
 </resources>

--- a/library/src/com/briangriffey/notebook/PageTurnLayout.java
+++ b/library/src/com/briangriffey/notebook/PageTurnLayout.java
@@ -22,7 +22,7 @@ public class PageTurnLayout extends FrameLayout {
 	private Paint mPaint;
 	private int mCurrentPage;
 
-	private int mPageTouchSlop;
+	private int mPageTouchPercentageFromEdge;
 	private boolean mIsTurning;
 
 	private PageTurnDirection mDirection;
@@ -54,7 +54,7 @@ public class PageTurnLayout extends FrameLayout {
 		mBottomViewRect = new Rect();
 		mTopViewRect = new Rect();
 
-		mPageTouchSlop = (int) getResources().getDimension(R.dimen.touch_start_padding);
+		mPageTouchPercentageFromEdge = (int) getResources().getDimension(R.dimen.touch_from_edge_percentage);
 	}
 
 	protected boolean isTouchAPageTurnStart(MotionEvent ev) {
@@ -66,12 +66,17 @@ public class PageTurnLayout extends FrameLayout {
 	}
 
 	protected boolean isTouchNearEdge(MotionEvent ev) {
-		if (Math.abs(ev.getX() - getMeasuredWidth()) < mPageTouchSlop)
-			return true;
-		else if (ev.getX() < mPageTouchSlop)
-			return true;
-
-		return false;
+      if (getMeasuredWidth() == 0)
+        return false;
+  
+      float ratioFromPageEdge = ev.getX() / getMeasuredWidth() * 100;
+     
+      if (100 - ratioFromPageEdge < mPageTouchPercentageFromEdge)
+        return true;
+      else if (ratioFromPageEdge < mPageTouchPercentageFromEdge)
+        return true;
+  
+      return false;
 	}
 	
 	protected PageTurnDirection getPageTurnDirection(MotionEvent ev) {


### PR DESCRIPTION
nexus 10 has so many pixels that the page turn wouldnt trigger unless the user can really hit the edge
which is not possible if it is in a case.
